### PR TITLE
📬 v1.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Hier gibt es eine Übersicht der Änderungen zwischen den Versionen.
 
+## 30.06.2026 - v1.5.0
+- Bei der Adresseingabe lassen sich jetzt mit einem Klick die Adresse, die Organisation oder die meistbenutzten bisherigen Adressen übernehmen. #32
+- [Eircodes](https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland) können als Adressen hinterlegt werden #36
+
 ## 27.05.2026 - v1.4.1
 - Fix: Verbesserte Anzeige von Zeitzonen.
     - Im öffentlichen Bereich gibt es jetzt einen Alert, wenn nicht Europe/Berlin Zeitzone vom Browser benutzt wird.

--- a/backend/app/Http/Controllers/EventController.php
+++ b/backend/app/Http/Controllers/EventController.php
@@ -4,34 +4,40 @@ namespace App\Http\Controllers;
 
 use App\Enums\MobilizonEventStatus;
 use App\Models\CreatedEvent;
+use App\Models\Mobilizon;
 use App\Models\SeriesEvent;
+use App\Models\SingleEvent;
 use App\Models\UploadedEvent;
 use App\Models\ImportedEvent;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
 
 class EventController extends Controller implements HasMiddleware
 {
-    public static function middleware()
+    public static function middleware(): array
     {
-        return ['auth'];
+        return [
+            'auth',
+            new Middleware('in_group', only: ['suggestedAddresses']),
+        ];
     }
 
     public function index(Request $request): JsonResponse
     {
         $events = CreatedEvent::all();
 
-        $singleEventsCount   = $events->filter(fn ($e) => $e->single_events_id !== null)->count();
-        $seriesEventsCount   = $events->filter(fn ($e) => $e->series_events_id !== null)->count();
-        $uploadedEventsCount = $events->filter(fn ($e) => $e->uploaded_events_id !== null)->count();
-        $importedEventsCount = $events->filter(fn ($e) => $e->imported_events_id !== null)->count();
+        $singleEventsCount   = $events->filter(fn($e) => $e->single_events_id !== null)->count();
+        $seriesEventsCount   = $events->filter(fn($e) => $e->series_events_id !== null)->count();
+        $uploadedEventsCount = $events->filter(fn($e) => $e->uploaded_events_id !== null)->count();
+        $importedEventsCount = $events->filter(fn($e) => $e->imported_events_id !== null)->count();
 
-        $confirmedEvents = $events->filter(fn ($e) => $e->getStatus() === MobilizonEventStatus::CONFIRMED->value)->count();
-        $tentativeEvents = $events->filter(fn ($e) => $e->getStatus() === MobilizonEventStatus::TENTATIVE->value)->count();
-        $cancelledEvents = $events->filter(fn ($e) => $e->getStatus() === MobilizonEventStatus::CANCELLED->value)->count();
+        $confirmedEvents = $events->filter(fn($e) => $e->getStatus() === MobilizonEventStatus::CONFIRMED->value)->count();
+        $tentativeEvents = $events->filter(fn($e) => $e->getStatus() === MobilizonEventStatus::TENTATIVE->value)->count();
+        $cancelledEvents = $events->filter(fn($e) => $e->getStatus() === MobilizonEventStatus::CANCELLED->value)->count();
 
-        $incomingEvents = $events->filter(fn ($e) => $e->start >= now());
+        $incomingEvents = $events->filter(fn($e) => $e->start >= now());
 
         return response()->json([
             'singleEventsCount'     => $singleEventsCount,
@@ -44,6 +50,43 @@ class EventController extends Controller implements HasMiddleware
             'incomingEventsCount'   => $incomingEvents,
             'test'                  => $events[0]->getRelatedEvent()->mobilizon_fields['status'] === MobilizonEventStatus::CONFIRMED,
             'confirmed'             => MobilizonEventStatus::CONFIRMED
+        ]);
+    }
+
+    public function suggestedAddresses(Request $request): JsonResponse
+    {
+        $groupId = (int) $request->input('mobilizon_group_id');
+
+        $frequencies = [];
+
+        foreach ([SingleEvent::class, SeriesEvent::class, ImportedEvent::class, UploadedEvent::class] as $eventModel) {
+            foreach ($eventModel::where('mobilizon_group_id', $groupId)->pluck('mobilizon_fields') as $fields) {
+                $address = is_array($fields) ? ($fields['physicalAddress'] ?? null) : null;
+
+                if (!is_array($address) || empty($address['geom'])) {
+                    continue;
+                }
+
+                // Nach Adresstext zusammenfassen, nicht nach geom – dieselbe
+                // Adresse kann je Termin minimal abweichende Koordinaten haben.
+                $key = mb_strtolower(trim(implode('|', array_filter([
+                    $address['street'] ?? '',
+                    $address['postalCode'] ?? '',
+                    $address['locality'] ?? '',
+                ])))) ?: $address['geom'];
+
+                $frequencies[$key]['address'] ??= $address;
+                $frequencies[$key]['count'] = ($frequencies[$key]['count'] ?? 0) + 1;
+            }
+        }
+
+        usort($frequencies, fn($a, $b) => $b['count'] <=> $a['count']);
+
+        $group = Mobilizon::getInstance()->getGroup($groupId);
+
+        return response()->json([
+            'organisation_address' => is_array($group) ? ($group['physicalAddress'] ?? null) : null,
+            'frequent_addresses'   => array_map(fn($entry) => $entry['address'], array_slice($frequencies, 0, 2)),
         ]);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -65,6 +65,7 @@ Route::prefix('single-events')->group(function () {
 
 Route::prefix('created-events')->group(function () {
     Route::get('/statistics/{group_id}', [EventController::class, 'index']);
+    Route::get('/suggested-addresses', [EventController::class, 'suggestedAddresses']);
     Route::post('/findEvent', [CreatedEventController::class, 'getEventId']);
     Route::post('/{createdEvent}', [CreatedEventController::class, 'update']);
     Route::delete('/{createdEvent}', [CreatedEventController::class, 'delete']);

--- a/frontend/src/components/AddressInput.vue
+++ b/frontend/src/components/AddressInput.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+import InputText from '@/components/KERN/inputs/InputText.vue';
+import Card from '@/components/KERN/Card.vue';
+import Button from '@/components/KERN/Button.vue';
+import { buildSuggestions } from '@/composables/EventCreateFormComposable';
+import { getSuggestedAddresses } from '@/lib/dsgClient';
+import { addressDefaults, type AddressForm } from '@/types/Mobilizon';
+
+const rawAddress = defineModel<string>({ default: '' });
+const address = defineModel<AddressForm>('address');
+
+interface Props {
+    name: string;
+    label?: string;
+    errors?: string;
+    suggestions?: string[];
+    mobilizonGroupId?: number | string | null;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    suggestions: () => [],
+});
+
+// Manuelle Eingabe: nur die Beschreibung setzen, <Map> ergänzt die Geokoordinaten.
+const onInput = () => {
+    address.value = { ...addressDefaults, description: rawAddress.value };
+};
+
+interface AddressCard {
+    label: string;
+    display: string;
+    address: AddressForm;
+}
+
+const cards = ref<AddressCard[]>([]);
+
+const toCard = (label: string, partial: Partial<AddressForm>): AddressCard | null => {
+    const full = { ...addressDefaults, ...partial } as AddressForm;
+    const display = buildSuggestions([full])[0];
+
+    if (!display || !full.geom) return null;
+
+    return { label, display, address: { ...full, description: display } };
+};
+
+const loadCards = async (groupId?: number | string | null) => {
+    cards.value = [];
+    if (!groupId) return;
+
+    const { organisationAddress, frequentAddresses } = await getSuggestedAddresses(groupId);
+
+    const result: AddressCard[] = [];
+    const seen = new Set<string>();
+
+    const push = (card: AddressCard | null) => {
+        if (!card || seen.has(card.display) || result.length >= 3) return;
+        seen.add(card.display);
+        result.push(card);
+    };
+
+    if (organisationAddress) push(toCard('Organisation', organisationAddress));
+    frequentAddresses.forEach((entry) => push(toCard('Häufig genutzt', entry)));
+
+    cards.value = result;
+};
+
+const selectCard = (card: AddressCard) => {
+    rawAddress.value = card.display;
+    address.value = { ...card.address };
+};
+
+watch(
+    () => props.mobilizonGroupId,
+    (groupId) => loadCards(groupId),
+    { immediate: true }
+);
+</script>
+<template>
+    <div class="flex flex-column gap-3">
+        <InputText
+            v-model="rawAddress"
+            :name="name"
+            :label="label"
+            :list="suggestions"
+            :errors="errors"
+            @input="onInput"
+        />
+        <div
+            v-if="cards.length"
+            class="flex flex-column md:flex-row gap-3"
+        >
+            <Card
+                v-for="card in cards"
+                :key="card.display"
+                class="flex-1"
+                body-class="gap-2"
+            >
+                <span class="kern-text kern-text--small">
+                    {{ card.display }}
+                    <br />
+                    ({{ card.label }})
+                </span>
+                <Button
+                    type="button"
+                    variant="primary"
+                    label="Adresse übernehmen"
+                    icon-left="check"
+                    @click="selectCard(card)"
+                />
+            </Card>
+        </div>
+    </div>
+</template>

--- a/frontend/src/components/KERN/inputs/InputText.vue
+++ b/frontend/src/components/KERN/inputs/InputText.vue
@@ -91,6 +91,7 @@ window.addEventListener('keydown', (event) => {
         :errors="errors"
         class="relative"
         :disabled="($attrs.disabled as boolean) ?? false"
+        style="z-index: 499;"
     >
         <input
             :id="name"

--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -82,17 +82,6 @@ async function geocodeAndUpdateMap(location: string) {
         if (data.length > 0) {
             const bestMatch = data[0];
 
-            const [lon, lat] = bestMatch.geom.split(';').map((coord) => parseFloat(coord.trim()));
-
-            // Move map view to the new coordinates
-            map.value!.setView([lat, lon], 13);
-
-            // Remove old marker
-            marker.value?.remove();
-
-            // Add new marker
-            marker.value = L.marker([lat, lon], { icon: myIcon }).addTo(map.value as L.Map);
-
             props.physicalAddress.street = bestMatch.street;
             props.physicalAddress.postalCode = bestMatch.postalCode?.trim();
             props.physicalAddress.locality = bestMatch.locality?.trim();
@@ -101,6 +90,18 @@ async function geocodeAndUpdateMap(location: string) {
             props.physicalAddress.geom = bestMatch.geom?.trim();
 
             suggestions.value = data;
+
+            const [lon, lat] = bestMatch.geom.split(';').map((coord) => parseFloat(coord.trim()));
+
+            if (map.value && Number.isFinite(lat) && Number.isFinite(lon)) {
+                map.value.setView([lat, lon], 13);
+
+                // Remove old marker
+                marker.value?.remove();
+
+                // Add new marker
+                marker.value = L.marker([lat, lon], { icon: myIcon }).addTo(map.value as L.Map);
+            }
         }
     } catch (err) {
         suggestions.value = [];

--- a/frontend/src/lib/dsgClient.ts
+++ b/frontend/src/lib/dsgClient.ts
@@ -3,7 +3,7 @@ import { axiosErrorHandler, dsgApi } from './dsgApi';
 import type { ZodSchema, ZodType } from 'zod';
 import type { AxiosError } from 'axios';
 
-import { MobilizonGroupSchema, type MobilizonGroup, MobilizonFieldsSchema } from '@/types/Mobilizon';
+import { MobilizonGroupSchema, type MobilizonGroup, MobilizonFieldsSchema, type AddressForm } from '@/types/Mobilizon';
 import { SingleEventResponseSchema, type SingleEventResponse } from '@/types/events/SingleEvents';
 import { type SeriesEvent, SeriesEventSchema } from '@/types/events/SeriesEvents';
 
@@ -92,6 +92,24 @@ export const getEventsStatistics = async (mobilizionGroupId: string | number): P
     } catch (error) {
         console.error('Error fetching events statistics:', error);
         throw error;
+    }
+};
+
+export const getSuggestedAddresses = async (
+    mobilizionGroupId: string | number
+): Promise<{ organisationAddress: Partial<AddressForm> | null; frequentAddresses: Partial<AddressForm>[] }> => {
+    try {
+        const { data } = await dsgApi.get('/created-events/suggested-addresses', {
+            params: { mobilizon_group_id: mobilizionGroupId },
+        });
+
+        return {
+            organisationAddress: data.organisation_address ?? null,
+            frequentAddresses: data.frequent_addresses ?? [],
+        };
+    } catch (error) {
+        console.error('Error fetching suggested addresses:', error);
+        return { organisationAddress: null, frequentAddresses: [] };
     }
 };
 

--- a/frontend/src/types/Mobilizon.ts
+++ b/frontend/src/types/Mobilizon.ts
@@ -47,7 +47,7 @@ export const AddressFormSchema = zod
             ctx.addIssue({
                 code: zod.ZodIssueCode.custom,
                 message:
-                    'Die Adresse konnte keinem Ort zugeordnet werden. Bitte wählen Sie einen Vorschlag aus der Liste aus.',
+                    'Die Adresse konnte keinem Ort zugeordnet werden. Wählen einen Vorschlag aus der Liste aus. Die Vorschläge erscheinen nur, wenn eine Adresse eingeben wurde, die in OpenStreetMap hinterlegt ist.',
             });
         }
     });

--- a/frontend/src/types/Mobilizon.ts
+++ b/frontend/src/types/Mobilizon.ts
@@ -22,46 +22,32 @@ export const addressDefaults = {
     id: null,
 };
 
+const optionalAddressString = (defaultValue: string) =>
+    zod
+        .string()
+        .nullable()
+        .default(defaultValue)
+        .transform((value) => value ?? '');
+
 export const AddressFormSchema = zod
     .object({
-        description: zod
-            .string()
-            .default(addressDefaults.description),
-        country: zod
-            .string()
-            .default(addressDefaults.country),
-        region: zod
-            .string()
-            .default(addressDefaults.region),
-        locality: zod
-            .string()
-            .default(addressDefaults.locality),
-        postalCode: zod
-            .string()
-            .default(addressDefaults.postalCode),
-        street: zod
-            .string()
-            .default(addressDefaults.street),
-        type: zod
-            .nativeEnum(EventPlaceType)
-            .default(EventPlaceType.OFFICE),
-        geom: zod
-            .string()
-            .default(addressDefaults.geom),
-        timezone: zod
-            .string()
-            .nullable()
-            .default(addressDefaults.timezone),
-        id: zod
-            .string()
-            .nullable()
-            .default(addressDefaults.id),
+        description: optionalAddressString(addressDefaults.description),
+        country: optionalAddressString(addressDefaults.country),
+        region: optionalAddressString(addressDefaults.region),
+        locality: optionalAddressString(addressDefaults.locality),
+        postalCode: optionalAddressString(addressDefaults.postalCode),
+        street: optionalAddressString(addressDefaults.street),
+        type: zod.nativeEnum(EventPlaceType).default(EventPlaceType.OFFICE),
+        geom: optionalAddressString(addressDefaults.geom),
+        timezone: zod.string().nullable().default(addressDefaults.timezone),
+        id: zod.string().nullable().default(addressDefaults.id),
     })
     .superRefine((value, ctx) => {
-        if (value.description && (!value.locality || !value.postalCode || !value.street)) {
+        if (value.description && !value.geom?.trim()) {
             ctx.addIssue({
                 code: zod.ZodIssueCode.custom,
-                message: 'Wenn eine Beschreibung angegeben ist, müssen Ort, Postleitzahl und Straße ausgefüllt sein.',
+                message:
+                    'Die Adresse konnte keinem Ort zugeordnet werden. Bitte wählen Sie einen Vorschlag aus der Liste aus.',
             });
         }
     });
@@ -74,17 +60,9 @@ export const pictureDefaults = {
 };
 
 export const PictureSchema = zod.object({
-    name: zod
-        .string()
-        .nonempty()
-        .default(pictureDefaults.name),
-    alt: zod
-        .string()
-        .nullable()
-        .default(pictureDefaults.alt),
-    url: zod
-        .string()
-        .optional(),
+    name: zod.string().nonempty().default(pictureDefaults.name),
+    alt: zod.string().nullable().default(pictureDefaults.alt),
+    url: zod.string().optional(),
     file: zod
         .instanceof(File)
         .optional()
@@ -136,32 +114,13 @@ export const MobilizonFieldsFormSchema = zod.object({
                 params: { mimeType: 'image/jpeg, image/png' },
             }
         ),
-    pictureAlt: zod
-        .string()
-        .optional()
-        .default(mobilizonFieldsDefaults.pictureAlt),
-    description: zod
-        .string()
-        .default(mobilizonFieldsDefaults.description),
-    category: zod
-        .string()
-        .nonempty()
-        .default(mobilizonFieldsDefaults.category),
-    tags: zod
-        .array(zod.string())
-        .default(mobilizonFieldsDefaults.tags),
-    joinOptions: zod
-        .string()
-        .nonempty()
-        .default(mobilizonFieldsDefaults.joinOptions),
-    language: zod
-        .string()
-        .nonempty()
-        .default(mobilizonFieldsDefaults.language),
-    status: zod
-        .string()
-        .nonempty()
-        .default(mobilizonFieldsDefaults.status),
+    pictureAlt: zod.string().optional().default(mobilizonFieldsDefaults.pictureAlt),
+    description: zod.string().default(mobilizonFieldsDefaults.description),
+    category: zod.string().nonempty().default(mobilizonFieldsDefaults.category),
+    tags: zod.array(zod.string()).default(mobilizonFieldsDefaults.tags),
+    joinOptions: zod.string().nonempty().default(mobilizonFieldsDefaults.joinOptions),
+    language: zod.string().nonempty().default(mobilizonFieldsDefaults.language),
+    status: zod.string().nonempty().default(mobilizonFieldsDefaults.status),
     externalParticipationUrl: zod
         .string()
         .nullable()
@@ -169,13 +128,8 @@ export const MobilizonFieldsFormSchema = zod.object({
         .refine((val) => !val || /^(https?:\/\/)([\w-]+\.)+[\w-]{2,}(\/[\w.-]*)*(\?.*)?$/.test(val), {
             message: 'Bei Angabe einer externen Teilnahme-URL bitte eine gültige URL eingeben.',
         }),
-    visibility: zod
-        .string()
-        .nonempty()
-        .default(mobilizonFieldsDefaults.visibility),
-    physicalAddress: AddressFormSchema
-        .nullable()
-        .optional(),
+    visibility: zod.string().nonempty().default(mobilizonFieldsDefaults.visibility),
+    physicalAddress: AddressFormSchema.nullable().optional(),
     onlineAddress: zod
         .string()
         .nullable()
@@ -188,18 +142,12 @@ export const MobilizonFieldsFormSchema = zod.object({
 export type MobilizonFieldsForm = zod.infer<typeof MobilizonFieldsFormSchema>;
 
 export const MobilizonFieldsSchema = zod.object({
-    picture: PictureSchema
-        .optional()
-        .nullable(),
+    picture: PictureSchema.optional().nullable(),
     description: zod
         .string()
         .refine((val) => stripHtml(val).length > 0, { message: 'Die Beschreibung darf nicht leer sein.' }),
-    category: zod
-        .string()
-        .nonempty(),
-    joinOptions: zod
-        .string()
-        .nonempty(),
+    category: zod.string().nonempty(),
+    joinOptions: zod.string().nonempty(),
     externalParticipationUrl: zod
         .string()
         .optional()
@@ -207,19 +155,10 @@ export const MobilizonFieldsSchema = zod.object({
         .refine((val) => !val || /^(https?:\/\/)([\w-]+\.)+[\w-]{2,}(\/[\w.-]*)*(\?.*)?$/.test(val), {
             message: 'Bei Angabe einer externen Teilnahme-URL bitte eine gültige URL eingeben.',
         }),
-    language: zod
-        .string()
-        .nonempty(),
-    status: zod
-        .string()
-        .nonempty(),
-    visibility: zod
-        .string()
-        .nonempty(),
-    tags: zod
-        .array(zod.string())
-        .optional()
-        .nullable(),
+    language: zod.string().nonempty(),
+    status: zod.string().nonempty(),
+    visibility: zod.string().nonempty(),
+    tags: zod.array(zod.string()).optional().nullable(),
     onlineAddress: zod
         .string()
         .nullable()
@@ -227,23 +166,15 @@ export const MobilizonFieldsSchema = zod.object({
         .refine((val) => !val || /^(https?:\/\/)([\w-]+\.)+[\w-]{2,}(\/[\w.-]*)*(\?.*)?$/.test(val), {
             message: 'Bei Angabe einer Online-Adresse bitte eine gültige URL eingeben.',
         }),
-    physicalAddress: AddressFormSchema
-        .optional()
-        .nullable(),
+    physicalAddress: AddressFormSchema.optional().nullable(),
 });
 
 export type MobilizonFields = zod.infer<typeof MobilizonFieldsSchema>;
 
 export const MobilizonGroupSchema = zod.object({
-    id: zod
-        .coerce
-        .number(),
-    name: zod
-        .string()
-        .nonempty(),
-    preferredUsername: zod
-        .string()
-        .nonempty(),
+    id: zod.coerce.number(),
+    name: zod.string().nonempty(),
+    preferredUsername: zod.string().nonempty(),
 });
 
 export type MobilizonGroup = zod.infer<typeof MobilizonGroupSchema>;

--- a/frontend/src/views/createdEvents/CreatedEventsEdit.vue
+++ b/frontend/src/views/createdEvents/CreatedEventsEdit.vue
@@ -33,6 +33,7 @@ import EventStatusBadge from '@/components/EventStatusBadge.vue';
 import InputRadios from '@/components/KERN/inputs/InputRadios.vue';
 import InputImage from '@/components/KERN/inputs/InputImage.vue';
 import InputTags from '@/components/InputTags.vue';
+import AddressInput from '@/components/AddressInput.vue';
 import LinkToDocs from '@/components/LinkToDocs.vue';
 import DeleteCreatedEvent from '@/components/DeleteCreatedEvent.vue';
 
@@ -204,13 +205,6 @@ const loadCreatedEvent = async () => {
     } finally {
         loading.value = false;
     }
-};
-
-const updateAddress = (address: string) => {
-    physicalAddress.value = {
-        ...addressDefaults,
-        description: address,
-    };
 };
 
 const getEventTypeLabel = (eventType: string): string => {
@@ -398,13 +392,14 @@ loadCreatedEvent();
                     name="onlineAddress"
                     :errors="submitCount === 0 ? undefined : errors.onlineAddress"
                 />
-                <InputText
+                <AddressInput
                     v-model="rawAddress"
+                    v-model:address="physicalAddress"
                     name="physicalAddress"
                     label="Adresse (optional)"
-                    :list="mapSuggestions"
+                    :suggestions="mapSuggestions"
+                    :mobilizon-group-id="mobilizon_group_id"
                     :errors="submitCount === 0 ? undefined : errors.physicalAddress"
-                    @input="updateAddress(rawAddress)"
                 />
             </div>
         </Fieldset>

--- a/frontend/src/views/importedEvents/ImportedEventsCreate.vue
+++ b/frontend/src/views/importedEvents/ImportedEventsCreate.vue
@@ -17,7 +17,6 @@ import InputUrl from '@/components/KERN/inputs/InputUrl.vue';
 import Alert from '@/components/KERN/Alert.vue';
 import Button from '@/components/KERN/Button.vue';
 import Fieldset from '@/components/KERN/Fieldset.vue';
-import InputText from '@/components/KERN/inputs/InputText.vue';
 import InputRichText from '@/components/KERN/inputs/InputRichText.vue';
 import InputSelect from '@/components/KERN/inputs/InputSelect.vue';
 import Divider from '@/components/KERN/cosmetics/Divider.vue';
@@ -25,11 +24,12 @@ import InputRadios from '@/components/KERN/inputs/InputRadios.vue';
 import Map from '@/components/Map.vue';
 import LinkToDocs from '@/components/LinkToDocs.vue';
 import InputTags from '@/components/InputTags.vue';
+import AddressInput from '@/components/AddressInput.vue';
 
 import { MobilizonEventJoinOptions, type Option } from '@/types/General';
 import type { RemoveKeys } from '@/types/Generics';
 
-import { addressDefaults, type AddressForm } from '@/types/Mobilizon';
+import { type AddressForm } from '@/types/Mobilizon';
 import {
     type ImportedEvent,
     ImportedEventSchema,
@@ -85,13 +85,6 @@ const onSubmit = handleSubmit(async (values: ImportedEventForm) => {
         isSubmitting.value = false;
     }
 });
-
-const updateAddress = (address: string) => {
-    physicalAddress.value = {
-        ...addressDefaults,
-        description: address,
-    };
-};
 
 watch(joinOptions, (newValue) => {
     if (newValue !== MobilizonEventJoinOptions.EXTERNAL) externalParticipationUrl.value = undefined;
@@ -240,13 +233,14 @@ loadMobilizionGroups(mobilizon_group_id, mobilizionGroupOptions);
                     :errors="submitCount === 0 ? undefined : errors.onlineAddress"
                 />
             </div>
-            <InputText
+            <AddressInput
                 v-model="rawAddress"
+                v-model:address="physicalAddress"
                 name="physicalAddress"
                 label="Adresse (optional)"
-                :list="mapSuggestions"
+                :suggestions="mapSuggestions"
+                :mobilizon-group-id="mobilizon_group_id"
                 :errors="submitCount === 0 ? undefined : errors.physicalAddress"
-                @input="updateAddress(rawAddress)"
             />
         </Fieldset>
         <Map

--- a/frontend/src/views/seriesEvents/SeriesEventsCreate.vue
+++ b/frontend/src/views/seriesEvents/SeriesEventsCreate.vue
@@ -48,6 +48,7 @@ import { addressDefaults, type AddressForm } from '@/types/Mobilizon';
 import InputImage from '@/components/KERN/inputs/InputImage.vue';
 import LinkToDocs from '@/components/LinkToDocs.vue';
 import InputTags from '@/components/InputTags.vue';
+import AddressInput from '@/components/AddressInput.vue';
 import InputCheckbox from '@/components/KERN/inputs/InputCheckbox.vue';
 import HolidaysSelect, { HolidaysPayload } from '@/components/HolidaysSelect.vue';
 
@@ -180,13 +181,6 @@ const createFromTemplate = async () => {
     } catch (error) {
         console.error(error);
     }
-};
-
-const updateAddress = (address: string) => {
-    physicalAddress.value = {
-        ...addressDefaults,
-        description: address,
-    };
 };
 
 const loadHolidays = async () => {
@@ -472,13 +466,14 @@ loadMobilizionGroups(mobilizon_group_id, mobilizionGroupOptions);
                     name="onlineAddress"
                     :errors="submitCount === 0 ? undefined : errors.onlineAddress"
                 />
-                <InputText
+                <AddressInput
                     v-model="rawAddress"
+                    v-model:address="physicalAddress"
                     name="physicalAddress"
                     label="Adresse (optional)"
-                    :list="mapSuggestions"
+                    :suggestions="mapSuggestions"
+                    :mobilizon-group-id="mobilizon_group_id"
                     :errors="submitCount === 0 ? undefined : errors.physicalAddress"
-                    @input="updateAddress(rawAddress)"
                 />
             </div>
         </Fieldset>

--- a/frontend/src/views/singleEvents/SingleEventsCreate.vue
+++ b/frontend/src/views/singleEvents/SingleEventsCreate.vue
@@ -32,6 +32,7 @@ import InputRadios from '@/components/KERN/inputs/InputRadios.vue';
 import InputImage from '@/components/KERN/inputs/InputImage.vue';
 import LinkToDocs from '@/components/LinkToDocs.vue';
 import InputTags from '@/components/InputTags.vue';
+import AddressInput from '@/components/AddressInput.vue';
 import Divider from '@/components/KERN/cosmetics/Divider.vue';
 
 import { MobilizonEventJoinOptions, type Option } from '@/types/General';
@@ -150,13 +151,6 @@ const createFromTemplate = async () => {
     } catch (error) {
         console.error(error);
     }
-};
-
-const updateAddress = (address: string) => {
-    physicalAddress.value = {
-        ...addressDefaults,
-        description: address,
-    };
 };
 
 watch(joinOptions, (newValue) => {
@@ -316,13 +310,14 @@ loadMobilizionGroups(mobilizon_group_id, mobilizionGroupOptions);
                     name="onlineAddress"
                     :errors="submitCount === 0 ? undefined : errors.onlineAddress"
                 />
-                <InputText
+                <AddressInput
                     v-model="rawAddress"
+                    v-model:address="physicalAddress"
                     name="physicalAddress"
                     label="Adresse (optional)"
-                    :list="mapSuggestions"
+                    :suggestions="mapSuggestions"
+                    :mobilizon-group-id="mobilizon_group_id"
                     :errors="submitCount === 0 ? undefined : errors.physicalAddress"
-                    @input="updateAddress(rawAddress)"
                 />
             </div>
         </Fieldset>

--- a/frontend/src/views/uploadedEvents/UploadedEventsCreate.vue
+++ b/frontend/src/views/uploadedEvents/UploadedEventsCreate.vue
@@ -17,7 +17,6 @@ import {
 
 import Button from '@/components/KERN/Button.vue';
 import Fieldset from '@/components/KERN/Fieldset.vue';
-import InputText from '@/components/KERN/inputs/InputText.vue';
 import InputSelect from '@/components/KERN/inputs/InputSelect.vue';
 import InputFile from '@/components/KERN/inputs/InputFile.vue';
 import Alert from '@/components/KERN/Alert.vue';
@@ -29,6 +28,7 @@ import Map from '@/components/Map.vue';
 import InputUrl from '@/components/KERN/inputs/InputUrl.vue';
 import InputRadios from '@/components/KERN/inputs/InputRadios.vue';
 import InputTags from '@/components/InputTags.vue';
+import AddressInput from '@/components/AddressInput.vue';
 import LinkToDocs from '@/components/LinkToDocs.vue';
 
 import { MobilizonEventJoinOptions, type Option } from '@/types/General';
@@ -40,7 +40,7 @@ import {
     UploadedEventFormSchema,
     UploadedEventSchema,
 } from '@/types/events/UploadedEvents';
-import { type AddressForm, addressDefaults, mobilizonFieldsDefaults } from '@/types/Mobilizon';
+import { type AddressForm, mobilizonFieldsDefaults } from '@/types/Mobilizon';
 
 const router = useRouter();
 const isSubmitting = ref<boolean>(false);
@@ -183,13 +183,6 @@ const prepareAcceptPayload = (): UploadedEventAcceptPayload => {
                 tags: tags.value,
             },
         })),
-    };
-};
-
-const updateAddress = (address: string) => {
-    physicalAddress.value = {
-        ...addressDefaults,
-        description: address,
     };
 };
 
@@ -349,13 +342,14 @@ loadMobilizionGroups(mobilizon_group_id, mobilizionGroupOptions);
                         name="onlineAddress"
                         :errors="submitCount === 0 ? undefined : errors.onlineAddress"
                     />
-                    <InputText
+                    <AddressInput
                         v-model="rawAddress"
+                        v-model:address="physicalAddress"
                         name="physicalAddress"
                         label="Adresse (optional)"
-                        :list="mapSuggestions"
+                        :suggestions="mapSuggestions"
+                        :mobilizon-group-id="mobilizon_group_id"
                         :errors="submitCount === 0 ? undefined : errors.physicalAddress"
-                        @input="updateAddress(rawAddress)"
                     />
                 </div>
             </Fieldset>


### PR DESCRIPTION
- Bei der Adresseingabe lassen sich jetzt mit einem Klick die Adresse, die Organisation oder die meistbenutzten bisherigen Adressen übernehmen. #32
- [Eircodes](https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland) können als Adressen hinterlegt werden #36